### PR TITLE
Less chrome-specific full-screen

### DIFF
--- a/app/assets/javascripts/scoreboard.js
+++ b/app/assets/javascripts/scoreboard.js
@@ -10,7 +10,10 @@ $(document).ready(function(){
   });
 
   $('.scoreboard').on('click', 'button.fullscreen', function(){
-    $('.scoreboard-content').get(0).webkitRequestFullscreen();
+    var scoreboard = $('.scoreboard-content').get(0);
+    if (scoreboard.requestFullscreen) {
+      scoreboard.requestFullscreen();
+    }
   });
 });
 

--- a/app/assets/stylesheets/scoreboard.css
+++ b/app/assets/stylesheets/scoreboard.css
@@ -24,14 +24,19 @@ img.scoreboard-sort-loading{
   overflow: scroll;
 }
 
-.scoreboard-content:not(:-wekbit-full-screen) {
+.scoreboard-content {
   margin-top: 10px;
 }
 
-.scoreboard-content:-webkit-full-screen {
+.scoreboard-content:fullscreen {
+  margin-top: 0;
   border-radius: 6px;
   padding: 5px;
   width: 98%;
+}
+
+.scoreboard-content::backdrop {
+  background-color: lightblue;
 }
 
 table.scoreboard{


### PR DESCRIPTION
Since this app was written, the fullscreen api has (just) moved out of
prefix land. Firefox 64, Chrome 71 (both released in December).  IE/Edge
and Safari are still out of luck, but practically speaking, we only need
this to work on exactly one computer.