### PR TITLE
Make newly approved users judges.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   scope :unapproved, -> { where.not approved: true }
 
   def approve!
-    update! approved: true
+    update! approved: true, judge: true
   end
 
   def has_role?(role)


### PR DESCRIPTION
Requested by Pires. _Nearly_ every user that signs up for the site is doing so because they're going to judge a maneuver. Seemed like the easiest way to do that.