### PR TITLE
This is a possible other fix to the auto-load/eager-load paths problem.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require 'app_form_builder'
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+  default_form_builder AppFormBuilder
 
   private
 

--- a/app/views/onboard_judgings/new.haml
+++ b/app/views/onboard_judgings/new.haml
@@ -2,7 +2,7 @@
   %h1 Onboard Judging
   %h3 Participant #{@participant.display_information(:number, :name)}
   %hr
-  = form_for OnboardJudging.new, builder: AppFormBuilder do |f|
+  = form_for OnboardJudging.new do |f|
     = f.hidden_field :participant_id, value: @participant.id
     %fieldset.form-group
       %legend Time Elapsed

--- a/app/views/onboard_judgings/show.haml
+++ b/app/views/onboard_judgings/show.haml
@@ -4,7 +4,7 @@
   - if current_user.admin? && @record.creator.present?
     %h3 Score recorded by #{@record.creator.name}
   %hr
-  = form_for @record, builder: AppFormBuilder do |f|
+  = form_for @record do |f|
     = f.hidden_field :participant_id, value: @participant.id
     %fieldset.form-group
       %legend Time elapsed:

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,7 @@ module UmasstransitRodeo
     # -- all .rb files in that directory are automatically loaded.
     config.encoding = 'utf-8'
     config.time_zone = 'Eastern Time (US & Canada)'
-    config.autoload_paths << Rails.root.join('lib')
-    config.eager_load_paths << Rails.root.join('lib')
+
     config.assets.paths << Rails.root.join('node_modules')
   end
 end


### PR DESCRIPTION
I figure it's actually fine to just set the default form builder for all of them.

There's a _lot_ of debate on the Internet over whether `/lib` is "supposed" to be in `auto_load_paths` or `eager_log_paths`. This works too. Any thoughts?