### PR TITLE
Slight improvement to archive assets task

### DIFF
--- a/archive.ru
+++ b/archive.ru
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+not_found = ->(_) { [404, { 'Content-Type' => 'text/plain' }, ['Not Found']] }
+run Rack::Static.new(not_found, urls: [''], root: 'archive', index: 'index.html')

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -19,10 +19,11 @@ namespace :roadeo do
       end
     end
 
-    desc 'Compile assets and add them to `/archive/assets/`'
-    task assets: [:environment, 'assets:precompile'] do
-      FileUtils.cp_r(Rails.root.join('public/assets'), ARCHIVE)
-      Rake::Task['assets:clobber'].invoke unless Rails.env.production?
+    desc 'Compile assets to `/archive/assets/`'
+    task assets: :environment do
+      app = Rails.application
+      manifest = Sprockets::Manifest.new(app.assets, ARCHIVE.join('assets'))
+      manifest.compile('manifest.js')
     end
   end
 end

--- a/spec/tasks/roadeo_archive_spec.rb
+++ b/spec/tasks/roadeo_archive_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe 'rake roadeo:archive:assets' do
   let(:assets) { ARCHIVE.join('assets') }
   let(:asset_files) { assets.glob('*').map(&:to_path) }
 
-  after(:all) do
-    ac = Rake::Task['assets:clobber']
-    ac.reenable
-    ac.invoke
-  end
-
   it 'creates the assets directory' do
     task.invoke
     expect(assets).to exist
@@ -55,10 +49,5 @@ RSpec.describe 'rake roadeo:archive:assets' do
     fontdir = assets.join('@fortawesome/fontawesome-free/webfonts')
     expect(fontdir).to exist
     expect(fontdir.glob('fa-*')).to be_present
-  end
-
-  it 'Clobbers generated assets in public/assets' do
-    expect(Rake::Task['assets:clobber']).to receive(:invoke).and_call_original
-    task.invoke
   end
 end


### PR DESCRIPTION
I was trying to find a way to quiet the asset compilation when running specs. I succeeded, and in the process I also found a way to just compile the assets where I wanted them rather than copying and clobbering.

Finally, I added a rack app that serves up the archived site for inspection.