### PR TITLE
allow `ngrok` hosts for development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  #allow ngrok to work
+  config.hosts << /[a-z0-9-]+\.ngrok\.io/
 end


### PR DESCRIPTION
without this, I wasn't able to connect using an `ngrok` URL. Now, I can.