### PR TITLE
Fix `bin/rails` and `bin/rake` in prod

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path("spring", __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-load File.expand_path("spring", __dir__)
 require_relative "../config/boot"
 require "rake"
 Rake.application.run


### PR DESCRIPTION
The app update task (#131) erroneously added a second `load` line to these two scripts.

Newer `spring` handles all the exception catching in `bin/spring`, but we're currently held back to Spring 2.x. So this causes both scripts to fail in production.