### PR TITLE
Add version number to old migrations

### DIFF
--- a/db/migrate/20160323201630_create_participants.rb
+++ b/db/migrate/20160323201630_create_participants.rb
@@ -1,4 +1,4 @@
-class CreateParticipants < ActiveRecord::Migration
+class CreateParticipants < ActiveRecord::Migration[4.2]
   def change
     create_table :participants do |t|
       t.string :name

--- a/db/migrate/20160323201642_create_buses.rb
+++ b/db/migrate/20160323201642_create_buses.rb
@@ -1,4 +1,4 @@
-class CreateBuses < ActiveRecord::Migration
+class CreateBuses < ActiveRecord::Migration[4.2]
   def change
     create_table :buses do |t|
       t.string :number

--- a/db/migrate/20160323201710_create_maneuvers.rb
+++ b/db/migrate/20160323201710_create_maneuvers.rb
@@ -1,4 +1,4 @@
-class CreateManeuvers < ActiveRecord::Migration
+class CreateManeuvers < ActiveRecord::Migration[4.2]
   def change
     create_table :maneuvers do |t|
       t.string :name

--- a/db/migrate/20160323203733_add_bus_id_to_participants.rb
+++ b/db/migrate/20160323203733_add_bus_id_to_participants.rb
@@ -1,4 +1,4 @@
-class AddBusIdToParticipants < ActiveRecord::Migration
+class AddBusIdToParticipants < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :bus_id, :integer
   end

--- a/db/migrate/20160323210307_add_sequence_number_to_maneuvers.rb
+++ b/db/migrate/20160323210307_add_sequence_number_to_maneuvers.rb
@@ -1,4 +1,4 @@
-class AddSequenceNumberToManeuvers < ActiveRecord::Migration
+class AddSequenceNumberToManeuvers < ActiveRecord::Migration[4.2]
   def change
     add_column :maneuvers, :sequence_number, :integer
   end

--- a/db/migrate/20160323211058_remove_completed_as_designed_and_reversed_direction_from_maneuvers.rb
+++ b/db/migrate/20160323211058_remove_completed_as_designed_and_reversed_direction_from_maneuvers.rb
@@ -1,4 +1,4 @@
-class RemoveCompletedAsDesignedAndReversedDirectionFromManeuvers < ActiveRecord::Migration
+class RemoveCompletedAsDesignedAndReversedDirectionFromManeuvers < ActiveRecord::Migration[4.2]
   def change
     remove_column :maneuvers, :completed_as_designed, :boolean
     remove_column :maneuvers, :reversed_direction, :boolean

--- a/db/migrate/20160323211151_create_maneuver_participants.rb
+++ b/db/migrate/20160323211151_create_maneuver_participants.rb
@@ -1,4 +1,4 @@
-class CreateManeuverParticipants < ActiveRecord::Migration
+class CreateManeuverParticipants < ActiveRecord::Migration[4.2]
   def change
     create_table :maneuver_participants do |t|
       t.integer :maneuver_id

--- a/db/migrate/20160323213013_create_obstacles.rb
+++ b/db/migrate/20160323213013_create_obstacles.rb
@@ -1,4 +1,4 @@
-class CreateObstacles < ActiveRecord::Migration
+class CreateObstacles < ActiveRecord::Migration[4.2]
   def change
     create_table :obstacles do |t|
       t.integer :x

--- a/db/migrate/20160323213045_create_distance_targets.rb
+++ b/db/migrate/20160323213045_create_distance_targets.rb
@@ -1,4 +1,4 @@
-class CreateDistanceTargets < ActiveRecord::Migration
+class CreateDistanceTargets < ActiveRecord::Migration[4.2]
   def change
     create_table :distance_targets do |t|
       t.integer :x

--- a/db/migrate/20160323213141_remove_obstacles_and_distance_targets_from_maneuvers.rb
+++ b/db/migrate/20160323213141_remove_obstacles_and_distance_targets_from_maneuvers.rb
@@ -1,4 +1,4 @@
-class RemoveObstaclesAndDistanceTargetsFromManeuvers < ActiveRecord::Migration
+class RemoveObstaclesAndDistanceTargetsFromManeuvers < ActiveRecord::Migration[4.2]
   def change
     remove_column :maneuvers, :obstacles, :string
     remove_column :maneuvers, :distance_targets, :string

--- a/db/migrate/20160324181415_add_speed_target_and_has_stops_count_to_maneuvers.rb
+++ b/db/migrate/20160324181415_add_speed_target_and_has_stops_count_to_maneuvers.rb
@@ -1,4 +1,4 @@
-class AddSpeedTargetAndHasStopsCountToManeuvers < ActiveRecord::Migration
+class AddSpeedTargetAndHasStopsCountToManeuvers < ActiveRecord::Migration[4.2]
   def change
     add_column :maneuvers, :speed_target, :integer
     add_column :maneuvers, :has_stops_count, :boolean

--- a/db/migrate/20160324181500_add_speed_achieved_and_stops_made_to_maneuver_participants.rb
+++ b/db/migrate/20160324181500_add_speed_achieved_and_stops_made_to_maneuver_participants.rb
@@ -1,4 +1,4 @@
-class AddSpeedAchievedAndStopsMadeToManeuverParticipants < ActiveRecord::Migration
+class AddSpeedAchievedAndStopsMadeToManeuverParticipants < ActiveRecord::Migration[4.2]
   def change
     add_column :maneuver_participants, :speed_achieved, :integer
     add_column :maneuver_participants, :stops_made, :integer

--- a/db/migrate/20160324183424_changed_reversed_direction_to_integer.rb
+++ b/db/migrate/20160324183424_changed_reversed_direction_to_integer.rb
@@ -1,4 +1,4 @@
-class ChangedReversedDirectionToInteger < ActiveRecord::Migration
+class ChangedReversedDirectionToInteger < ActiveRecord::Migration[4.2]
   def up
     change_column :maneuver_participants, :reversed_direction, :integer
   end

--- a/db/migrate/20160324192400_add_name_to_distance_targets.rb
+++ b/db/migrate/20160324192400_add_name_to_distance_targets.rb
@@ -1,4 +1,4 @@
-class AddNameToDistanceTargets < ActiveRecord::Migration
+class AddNameToDistanceTargets < ActiveRecord::Migration[4.2]
   def change
     add_column :distance_targets, :name, :string
   end

--- a/db/migrate/20160324193453_add_minimum_to_distance_targets.rb
+++ b/db/migrate/20160324193453_add_minimum_to_distance_targets.rb
@@ -1,4 +1,4 @@
-class AddMinimumToDistanceTargets < ActiveRecord::Migration
+class AddMinimumToDistanceTargets < ActiveRecord::Migration[4.2]
   def change
     add_column :distance_targets, :minimum, :integer
   end

--- a/db/migrate/20160324201321_add_type_to_obstacles.rb
+++ b/db/migrate/20160324201321_add_type_to_obstacles.rb
@@ -1,4 +1,4 @@
-class AddTypeToObstacles < ActiveRecord::Migration
+class AddTypeToObstacles < ActiveRecord::Migration[4.2]
   def change
     add_column :obstacles, :obstacle_type, :string
   end

--- a/db/migrate/20160325014218_remove_distance_achieved_from_maneuver_participants.rb
+++ b/db/migrate/20160325014218_remove_distance_achieved_from_maneuver_participants.rb
@@ -1,4 +1,4 @@
-class RemoveDistanceAchievedFromManeuverParticipants < ActiveRecord::Migration
+class RemoveDistanceAchievedFromManeuverParticipants < ActiveRecord::Migration[4.2]
   def change
     remove_column :maneuver_participants, :distance_achieved, :integer
   end

--- a/db/migrate/20160325014341_add_distances_achieved_to_maneuver_participants.rb
+++ b/db/migrate/20160325014341_add_distances_achieved_to_maneuver_participants.rb
@@ -1,4 +1,4 @@
-class AddDistancesAchievedToManeuverParticipants < ActiveRecord::Migration
+class AddDistancesAchievedToManeuverParticipants < ActiveRecord::Migration[4.2]
   def change
     add_column :maneuver_participants, :distances_achieved, :string
   end

--- a/db/migrate/20160325041711_change_maneuver_special_attributes.rb
+++ b/db/migrate/20160325041711_change_maneuver_special_attributes.rb
@@ -1,4 +1,4 @@
-class ChangeManeuverSpecialAttributes < ActiveRecord::Migration
+class ChangeManeuverSpecialAttributes < ActiveRecord::Migration[4.2]
   def up
     remove_column :maneuvers, :has_stops_count, :boolean
     add_column :maneuvers, :counts_additional_stops, :boolean

--- a/db/migrate/20160325212946_create_circle_check_scores.rb
+++ b/db/migrate/20160325212946_create_circle_check_scores.rb
@@ -1,4 +1,4 @@
-class CreateCircleCheckScores < ActiveRecord::Migration
+class CreateCircleCheckScores < ActiveRecord::Migration[4.2]
   def change
     create_table :circle_check_scores do |t|
       t.integer :total_defects

--- a/db/migrate/20160325220900_create_quiz_scores.rb
+++ b/db/migrate/20160325220900_create_quiz_scores.rb
@@ -1,4 +1,4 @@
-class CreateQuizScores < ActiveRecord::Migration
+class CreateQuizScores < ActiveRecord::Migration[4.2]
   def change
     create_table :quiz_scores do |t|
       t.float :points_achieved

--- a/db/migrate/20160329203856_remove_buses.rb
+++ b/db/migrate/20160329203856_remove_buses.rb
@@ -1,4 +1,4 @@
-class RemoveBuses < ActiveRecord::Migration
+class RemoveBuses < ActiveRecord::Migration[4.2]
   def change
     drop_table :buses
   end

--- a/db/migrate/20160330144204_create_onboard_judgings.rb
+++ b/db/migrate/20160330144204_create_onboard_judgings.rb
@@ -1,4 +1,4 @@
-class CreateOnboardJudgings < ActiveRecord::Migration
+class CreateOnboardJudgings < ActiveRecord::Migration[4.2]
   def change
     create_table :onboard_judgings do |t|
       t.integer :participant_id

--- a/db/migrate/20160330165820_change_time_elapsed_to_minutes_and_seconds.rb
+++ b/db/migrate/20160330165820_change_time_elapsed_to_minutes_and_seconds.rb
@@ -1,4 +1,4 @@
-class ChangeTimeElapsedToMinutesAndSeconds < ActiveRecord::Migration
+class ChangeTimeElapsedToMinutesAndSeconds < ActiveRecord::Migration[4.2]
   def change
     add_column :onboard_judgings, :minutes_elapsed, :integer
   end

--- a/db/migrate/20160330172355_add_sudden_starts_to_onboard_judgings.rb
+++ b/db/migrate/20160330172355_add_sudden_starts_to_onboard_judgings.rb
@@ -1,4 +1,4 @@
-class AddSuddenStartsToOnboardJudgings < ActiveRecord::Migration
+class AddSuddenStartsToOnboardJudgings < ActiveRecord::Migration[4.2]
   def change
     add_column :onboard_judgings, :sudden_starts, :integer
   end

--- a/db/migrate/20160331130902_devise_create_users.rb
+++ b/db/migrate/20160331130902_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users, force: true) do |t|
       ## Database authenticatable

--- a/db/migrate/20160331132019_add_roles_to_users.rb
+++ b/db/migrate/20160331132019_add_roles_to_users.rb
@@ -1,4 +1,4 @@
-class AddRolesToUsers < ActiveRecord::Migration
+class AddRolesToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :judge, :boolean, null: false, default: false
     add_column :users, :quiz_scorer, :boolean, null: false, default: false

--- a/db/migrate/20160401184447_remove_bus_id_from_users.rb
+++ b/db/migrate/20160401184447_remove_bus_id_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveBusIdFromUsers < ActiveRecord::Migration
+class RemoveBusIdFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :participants, :bus_id, :integer
   end

--- a/db/migrate/20160401192924_create_versions.rb
+++ b/db/migrate/20160401192924_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :versions do |t|
       t.string   :item_type, :null => false

--- a/db/migrate/20160406143950_recreate_buses.rb
+++ b/db/migrate/20160406143950_recreate_buses.rb
@@ -1,4 +1,4 @@
-class RecreateBuses < ActiveRecord::Migration
+class RecreateBuses < ActiveRecord::Migration[4.2]
   def change
     create_table :buses do |t|
       t.string :number

--- a/db/migrate/20160406145940_readd_bus_id_to_participants.rb
+++ b/db/migrate/20160406145940_readd_bus_id_to_participants.rb
@@ -1,4 +1,4 @@
-class ReaddBusIdToParticipants < ActiveRecord::Migration
+class ReaddBusIdToParticipants < ActiveRecord::Migration[4.2]
   def change
     add_column :participants, :bus_id, :integer
   end

--- a/db/migrate/20161202151543_add_approved_to_users.rb
+++ b/db/migrate/20161202151543_add_approved_to_users.rb
@@ -1,4 +1,4 @@
-class AddApprovedToUsers < ActiveRecord::Migration
+class AddApprovedToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :approved, :boolean, default: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,14 +12,14 @@
 
 ActiveRecord::Schema.define(version: 2021_02_19_134558) do
 
-  create_table "buses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "buses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["number"], name: "index_buses_on_number", unique: true
   end
 
-  create_table "circle_check_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "circle_check_scores", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "total_defects"
     t.integer "defects_found"
     t.integer "participant_id"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["participant_id"], name: "index_circle_check_scores_on_participant_id", unique: true
   end
 
-  create_table "distance_targets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "distance_targets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "x"
     t.integer "y"
     t.integer "direction"
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.integer "minimum"
   end
 
-  create_table "maneuver_participants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "maneuver_participants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "maneuver_id"
     t.integer "participant_id"
     t.string "obstacles_hit"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["maneuver_id", "participant_id"], name: "index_maneuver_participants_on_maneuver_id_and_participant_id", unique: true
   end
 
-  create_table "maneuvers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "maneuvers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["sequence_number"], name: "index_maneuvers_on_sequence_number", unique: true
   end
 
-  create_table "obstacles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "obstacles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "x"
     t.integer "y"
     t.integer "point_value"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.string "obstacle_type"
   end
 
-  create_table "onboard_judgings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "onboard_judgings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "participant_id"
     t.integer "score"
     t.integer "seconds_elapsed"
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["participant_id"], name: "index_onboard_judgings_on_participant_id", unique: true
   end
 
-  create_table "participants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "participants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "number"
     t.datetime "created_at", null: false
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["number"], name: "index_participants_on_number", unique: true
   end
 
-  create_table "quiz_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "quiz_scores", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.float "points_achieved"
     t.float "total_points"
     t.integer "participant_id"
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["participant_id"], name: "index_quiz_scores_on_participant_id", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false


### PR DESCRIPTION
This isn't holding me up, I can just run db:schema:load manually.

But, Capistrano only runs db:migrate by default, so cold deploys work better with these versions.