### PR TITLE
Remove mail work-arounds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,15 +13,6 @@ gem 'haml-rails'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'mysql2', '~> 0.5.2'
-
-# The net-* gems are former default gems that are dependencies of mail.
-# Mail 2.8.0 fixes the dependencies, but has broken file permissions.
-# This whole block can be removed once mail 2.8.1 is released.
-gem 'mail', '!= 2.8.0'
-gem 'net-smtp'
-gem 'net-imap'
-gem 'net-pop'
-
 gem 'openssl'
 gem 'paper_trail'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -388,11 +391,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   listen (~> 3.0.5)
-  mail (!= 2.8.0)
   mysql2 (~> 0.5.2)
-  net-imap
-  net-pop
-  net-smtp
   openssl
   paper_trail
   pry-byebug


### PR DESCRIPTION
`mail` 2.8.0.1 was released that fixes Ruby 3.1 compatibility without broken file permissions.