### PR TITLE
Rogue log in link

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -25,4 +25,3 @@
 .form-group
   Unhappy?
   =button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger'
-= render "devise/shared/links"


### PR DESCRIPTION
For some reason Devise(?) put a log in link on the edit account page, which just creates a controller error. Now it's gone!