### PR TITLE
Locking scores

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -43,7 +43,7 @@ module Admin
       params.require(:user).permit :admin, :quiz_scorer,
                                    :circle_check_scorer,
                                    :master_of_ceremonies,
-                                   :judge
+                                   :judge, :lock_scores
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -49,7 +49,7 @@ module Admin
 
     def catch_lock_scores
       lock_scores = params.fetch(:user, {}).permit(:lock_scores)
-      return if lock_scores.blank?
+      return if current_user.id != params.require(:id).to_i || lock_scores.blank?
 
       @user.update lock_scores
       notice = case lock_scores

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ module Admin
     def update
       return unless @user.update user_params
 
-      redirect_to admin_users_path, notice: 'User has been updated.'
+      redirect_back(fallback_location: admin_users_path, notice: 'User has been updated.')
     end
 
     private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -52,14 +52,14 @@ module Admin
       return if current_user.id != params.require(:id).to_i || lock_scores.blank?
 
       @user.update lock_scores
-      notice = case lock_scores
+      notice = case lock_scores[:lock_scores]
                when 'true'
                  'Scores have been locked.'
                when 'false'
                  if User.scoring_enabled?
-                   'Scores are still locked by other users.'
-                 else
                    'Scores have been unlocked.'
+                 else
+                   'Scores are still locked by other users!'
                  end
                end
 

--- a/app/helpers/scoreboard_helper.rb
+++ b/app/helpers/scoreboard_helper.rb
@@ -43,4 +43,14 @@ module ScoreboardHelper
       link_to_if allowed, '&mdash;'.html_safe, new
     end
   end
+
+  def format_locking_users(locking_users)
+    locking_users = locking_users.pluck(:name)
+    if current_user.lock_scores?
+      locking_users.delete(current_user.name)
+      "#{locking_users.join(', ')} and you"
+    else
+      locking_users.to_sentence
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,16 +10,16 @@ class User < ApplicationRecord
 
   scope :unapproved, -> { where.not approved: true }
 
+  def self.scoring_enabled?
+    where('users.admin = true OR users.master_of_ceremonies = true').pluck(:lock_scores).uniq == [false]
+  end
+
   def approve!
     update! approved: true, judge: true
   end
 
   def role?(role)
-    admin? || ((master_of_ceremonies? || scoring_enabled?) && send(role))
-  end
-
-  def scoring_enabled?
-    where('users.admin = true OR users.master_of_ceremonies = true').pluck(:lock_scores).uniq == [false]
+    admin? || ((master_of_ceremonies? || User.scoring_enabled?) && send(role))
   end
 
   # Require admins to approve users once they register.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,10 @@ class User < ApplicationRecord
   validates :encrypted_password, presence: true
 
   scope :unapproved, -> { where.not approved: true }
+  scope :score_lockers, -> { where(admin: true).or(where(master_of_ceremonies: true)).where({ lock_scores: true }) }
 
   def self.scoring_enabled?
-    where('users.admin = true OR users.master_of_ceremonies = true').pluck(:lock_scores).uniq == [false]
+    score_lockers.blank?
   end
 
   def approve!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   end
 
   def scoring_enabled?
-    true
+    where('users.admin = true OR users.master_of_ceremonies = true').pluck(:lock_scores).uniq == [false]
   end
 
   # Require admins to approve users once they register.

--- a/app/views/participants/scoreboard.haml
+++ b/app/views/participants/scoreboard.haml
@@ -1,16 +1,17 @@
 - if @participants_exist
   .scoreboard
-    %button.btn.btn-primary.fullscreen
-      %i.fas.fa-expand
-    = form_with model: [:admin, current_user], local: true do |f|
-      = f.hidden_field :lock_scores, value: !current_user.lock_scores
-      = f.button class: 'btn btn-primary' do
-        - if current_user.lock_scores
-          Unlock Scores
-          %i.fas.fa-lock-open
-        - else
-          Lock Scores
-          %i.fas.fa-lock
+    .form-inline
+      %button.btn.btn-primary.fullscreen
+        %i.fas.fa-expand
+      = form_with model: [:admin, current_user], local: true do |f|
+        = f.hidden_field :lock_scores, value: !current_user.lock_scores
+        = f.button class: 'btn btn-primary ml-2' do
+          - if current_user.lock_scores
+            Unlock Scores
+            %i.fas.fa-lock-open
+          - else
+            Lock Scores
+            %i.fas.fa-lock
     .scoreboard-content
       - table_classes = %w[scoreboard table table-bordered table-striped table-sm text-center]
       %table{class: table_classes, data: {sortList: sort_list(@sort_order)}}

--- a/app/views/participants/scoreboard.haml
+++ b/app/views/participants/scoreboard.haml
@@ -3,15 +3,16 @@
     .form-inline
       %button.btn.btn-primary.fullscreen
         %i.fas.fa-expand
-      = form_with model: [:admin, current_user], local: true do |f|
-        = f.hidden_field :lock_scores, value: !current_user.lock_scores
-        = f.button class: 'btn btn-primary ml-2' do
-          - if current_user.lock_scores
-            Unlock Scores
-            %i.fas.fa-lock-open
-          - else
-            Lock Scores
-            %i.fas.fa-lock
+      - if current_user
+        = form_with model: [:admin, current_user], local: true do |f|
+          = f.hidden_field :lock_scores, value: !current_user.lock_scores
+          = f.button class: 'btn btn-primary ml-2' do
+            - if current_user.lock_scores
+              Unlock Scores
+              %i.fas.fa-lock-open
+            - else
+              Lock Scores
+              %i.fas.fa-lock
     .scoreboard-content
       - table_classes = %w[scoreboard table table-bordered table-striped table-sm text-center]
       %table{class: table_classes, data: {sortList: sort_list(@sort_order)}}

--- a/app/views/participants/scoreboard.haml
+++ b/app/views/participants/scoreboard.haml
@@ -1,18 +1,23 @@
 - if @participants_exist
   .scoreboard
-    .form-inline
+    .d-flex.align-items-center
       %button.btn.btn-primary.fullscreen
         %i.fas.fa-expand
       - if current_user
         = form_with model: [:admin, current_user], local: true do |f|
           = f.hidden_field :lock_scores, value: !current_user.lock_scores
-          = f.button class: 'btn btn-primary ml-2' do
+          = f.button class: 'btn btn-primary mx-2' do
             - if current_user.lock_scores
               Unlock Scores
               %i.fas.fa-lock-open
             - else
               Lock Scores
               %i.fas.fa-lock
+      - if !User.scoring_enabled?
+        - if current_user.role?(:master_of_ceremonies)
+          Scores are locked by #{format_locking_users(User.score_lockers)}
+        - else
+          Scores are locked!
     .scoreboard-content
       - table_classes = %w[scoreboard table table-bordered table-striped table-sm text-center]
       %table{class: table_classes, data: {sortList: sort_list(@sort_order)}}

--- a/app/views/participants/scoreboard.haml
+++ b/app/views/participants/scoreboard.haml
@@ -2,6 +2,15 @@
   .scoreboard
     %button.btn.btn-primary.fullscreen
       %i.fas.fa-expand
+    = form_with model: [:admin, current_user], local: true do |f|
+      = f.hidden_field :lock_scores, value: !current_user.lock_scores
+      = f.button class: 'btn btn-primary' do
+        - if current_user.lock_scores
+          Unlock Scores
+          %i.fas.fa-lock-open
+        - else
+          Lock Scores
+          %i.fas.fa-lock
     .scoreboard-content
       - table_classes = %w[scoreboard table table-bordered table-striped table-sm text-center]
       %table{class: table_classes, data: {sortList: sort_list(@sort_order)}}

--- a/app/views/participants/scoreboard.haml
+++ b/app/views/participants/scoreboard.haml
@@ -1,12 +1,12 @@
 - if @participants_exist
   .scoreboard
     .d-flex.align-items-center
-      %button.btn.btn-primary.fullscreen
+      %button.btn.btn-primary.fullscreen.mr-2
         %i.fas.fa-expand
-      - if current_user
+      - if current_user&.role?(:master_of_ceremonies)
         = form_with model: [:admin, current_user], local: true do |f|
           = f.hidden_field :lock_scores, value: !current_user.lock_scores
-          = f.button class: 'btn btn-primary mx-2' do
+          = f.button class: 'btn btn-primary mr-2' do
             - if current_user.lock_scores
               Unlock Scores
               %i.fas.fa-lock-open
@@ -14,7 +14,7 @@
               Lock Scores
               %i.fas.fa-lock
       - if !User.scoring_enabled?
-        - if current_user.role?(:master_of_ceremonies)
+        - if current_user&.role?(:master_of_ceremonies)
           Scores are locked by #{format_locking_users(User.score_lockers)}
         - else
           Scores are locked!

--- a/app/views/participants/welcome.haml
+++ b/app/views/participants/welcome.haml
@@ -7,7 +7,6 @@
   - if Participant.any?
     To view the scoreboard, click
     = link_to 'here', scoreboard_participants_path
-    or on the button above.
   - else
     Once the #{event} has begun, you will be able to view the scoreboard here.
   .login-instructions

--- a/db/migrate/20240103205602_add_lock_scores_to_users.rb
+++ b/db/migrate/20240103205602_add_lock_scores_to_users.rb
@@ -1,0 +1,5 @@
+class AddLockScoresToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :lock_scores, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_19_134558) do
+ActiveRecord::Schema.define(version: 2024_01_03_205602) do
 
   create_table "buses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "number"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_134558) do
     t.boolean "master_of_ceremonies", default: false, null: false
     t.boolean "admin", default: false, null: false
     t.boolean "approved", default: false
+    t.boolean "lock_scores", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Fix #61 through a new parameter for each user, `lock_scores`. Only takes effect if that user is an admin or a master of ceremonies, and is toggled on the scoreboard page. The scoreboard page will display text if the scores are locked, and who is locking them if you have appropriate permissions (admin or master of ceremonies)