### PR TITLE
Fix factories with a `y` attribute

### DIFF
--- a/spec/factories/distance_targets.rb
+++ b/spec/factories/distance_targets.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :distance_target do
     name { 'Pivot cone' }
     x { 0 }
-    y { 0 }
+    add_attribute(:y) { 0 } # Kernel#y is a method added by Psych
     direction { 0 }
     intervals { 5 }
     multiplier { 5 }

--- a/spec/factories/obstacles.rb
+++ b/spec/factories/obstacles.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :obstacle do
     x { 0 }
-    y { 0 }
+    add_attribute(:y) { 0 } # Kernel#y is a method added by Psych
     point_value { 10 }
     obstacle_type { 'cone' }
     maneuver


### PR DESCRIPTION
Not sure how long this has been an issue, but `Kernel#y` is a method added by Psych, so we can't rely on FactoryBot's `method_missing` technique to define an attribute called `y`.

See thoughtbot/factory_bot#1397