### PR TITLE
Switch from pry to irb/debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'coffee-rails'
 gem 'devise', '~> 4.6'
 gem 'haml'
 gem 'haml-rails'
+gem 'irb'
 gem 'jquery-rails'
 gem 'mysql2', '~> 0.5.2'
 gem 'openssl'
@@ -55,6 +56,6 @@ end
 group :development, :test do
   gem 'factory_bot_rails'
   gem 'ffaker'
-  gem 'pry-byebug'
+  gem 'debug'
   gem 'rb-readline', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
-    byebug (11.1.3)
     capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -120,6 +119,9 @@ GEM
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.1.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -160,6 +162,10 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    irb (1.11.1)
+      rdoc
+      reline (>= 0.4.2)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -208,12 +214,8 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     popper_js (1.16.0)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
+    psych (5.1.2)
+      stringio
     public_suffix (4.0.6)
     puma (5.6.8)
       nio4r (~> 2.0)
@@ -262,8 +264,12 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
     redis (3.3.5)
     regexp_parser (2.2.1)
+    reline (0.4.2)
+      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -341,6 +347,7 @@ GEM
     sshkit (1.21.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stringio (3.1.0)
     temple (0.8.2)
     thor (1.2.2)
     tilt (2.0.10)
@@ -382,18 +389,19 @@ DEPENDENCIES
   capybara
   certified
   coffee-rails
+  debug
   devise (~> 4.6)
   exception_notification
   factory_bot_rails
   ffaker
   haml
   haml-rails
+  irb
   jquery-rails
   listen (~> 3.0.5)
   mysql2 (~> 0.5.2)
   openssl
   paper_trail
-  pry-byebug
   puma
   rack_session_access
   rails (~> 6.1.3)


### PR DESCRIPTION
The newest IRB has pretty good [debugger integration](https://st0012.dev/whats-new-in-ruby-3-2-irb).

As a side-effect, putting `irb` in the `Gemfile` gets us the newest console now.