### PR TITLE
Remove underscore-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'puma'
 gem 'rails', '~> 6.1.3'
 gem 'sassc-rails'
 gem 'uglifier'
-gem 'underscore-rails'
 
 group :production do
   gem 'exception_notification'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    underscore-rails (1.8.3)
     unicode-display_width (2.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -420,7 +419,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   timecop
   uglifier
-  underscore-rails
   webdrivers
 
 RUBY VERSION

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,5 @@
 //= require jquery
 //= require jquery_ujs
-//= require underscore
 //= require bootstrap
 //= require jquery.are-you-sure
 //= require tablesorter/dist/js/jquery.tablesorter


### PR DESCRIPTION
I didn't find any occurence of `_.` in our JS; I'm pretty sure that this JS-in-a-rubygem is unused.

It looks like its only use was removed in b73f1d63c3ec9244ed0c73ffd7e5053f284eaeaa (the same day it was added).