### PR TITLE
Switch from jquery-ujs to rails-ujs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'factory_bot_rails'
 gem 'haml'
 gem 'haml-rails'
 gem 'irb'
-gem 'jquery-rails'
 gem 'mutex_m' # Needed for Ruby >=3.4 on Rails <=7.1
 gem 'mysql2', '~> 0.5.6'
 gem 'openssl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,10 +171,6 @@ GEM
     irb (1.14.3)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jquery-rails (4.4.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
@@ -425,7 +421,6 @@ DEPENDENCIES
   haml
   haml-rails
   irb
-  jquery-rails
   listen
   mutex_m
   mysql2 (~> 0.5.6)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-//= require jquery3
+//= require jquery
 //= require rails-ujs
 //= require bootstrap
 //= require jquery.are-you-sure

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,5 @@
 //= require jquery3
-//= require jquery_ujs
+//= require rails-ujs
 //= require bootstrap
 //= require jquery.are-you-sure
 //= require tablesorter/dist/js/jquery.tablesorter

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,7 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the rails generate channel command.
 //
-//= require action_cable
+//= require actioncable
 //= require_self
 //= require_tree ./channels
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
+    "jquery": "^3.5.1",
     "jquery.are-you-sure": "^1.9.0",
     "tablesorter": "^2.32.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@ jquery.are-you-sure@^1.9.0:
   dependencies:
     jquery ">=1.4.2"
 
-jquery@>=1.2.6, jquery@>=1.4.2:
+jquery@^3.5.1, jquery@>=1.2.6, jquery@>=1.4.2:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==


### PR DESCRIPTION
Also switch to getting jquery from npm

Of course, rails-ujs is deprecated in its own way. But we're good until Rails 7.2.