### PR TITLE
Add (back) rubocop-rspec_rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-factory_bot
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development do
   gem 'rubocop-factory_bot', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
   gem 'spring'
   gem 'spring-watcher-listen'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,9 @@ GEM
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -443,6 +446,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   sassc-rails
   selenium-webdriver
   simplecov


### PR DESCRIPTION
The cops in this gem were removed from rubocop-rspec in 3.0