### PR TITLE
Two fixes for run-pty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,9 +240,10 @@
     },
     "node_modules/@lydell/node-pty": {
       "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/@lydell/node-pty/-/node-pty-1.0.3.tgz",
-      "integrity": "sha1-SZLPKxrr/0bJy3B2zs32RQQgD2k= sha512-nLTNwJXEPi1oMyzxRwqsLB4jCmhDrltQS/kAYhV05qbPo5NOIKpw2tb+Iok/yhd9zP9+E5Lu7sWDGD+G4fdKbQ==",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.0.3.tgz",
+      "integrity": "sha512-nLTNwJXEPi1oMyzxRwqsLB4jCmhDrltQS/kAYhV05qbPo5NOIKpw2tb+Iok/yhd9zP9+E5Lu7sWDGD+G4fdKbQ==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "@lydell/node-pty-darwin-arm64": "1.0.3",
         "@lydell/node-pty-darwin-x64": "1.0.3",
@@ -262,6 +263,62 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-IuEf8TXwo+wzoUEhqv+LtznwW94gMm4V9XVFMisFh+oRz0TNtnWHtgTCdWCVn4Dm3dpEDAjiAlTLx0ayC5uMVA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.0.3.tgz",
+      "integrity": "sha512-tfj6Zg9F5KkyCQQ2wCUXUW/1lcNgdWAVJNtt6gQH3X+fUueSrRl+R7xoWTcl5NGcfn2l7QWgUrjZcVKP3/ljTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.0.3.tgz",
+      "integrity": "sha512-5MTd7hbrvmO/de/B2MDhxjh3E109i5bSds6JtIcVR1M6+uCvWJrON5ibbvWIAqTHpFup20IyDv0cQJxVv9o9nA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.0.3.tgz",
+      "integrity": "sha512-XMANgXpBYGtKa5q+czro+TaJAyv3njbT7R81Pky+p7e4GwNdWtSUNBxtQm+O4ZLV0VJ1rNiMEHMyGOq8T9i4FA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/run-pty.json
+++ b/run-pty.json
@@ -7,6 +7,6 @@
     "defaultStatus": ["⏳", "S"]
   },
   {
-    "command": ["npm", "run", "build:css", "--watch"]
+    "command": ["npm", "run", "build:css", "--", "--watch"]
   }
 ]


### PR DESCRIPTION
1. The switch from Yarn to NPM only installed optional dependencies for the machine it was run on, so node-pty wouldn't work on anything other than `darwin-arm64`
2. ~~`--watch` flag needs to be to the build script, not to `npm`~~