### PR TITLE
Handful of Capistrano updates

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# config valid only for current version of Capistrano
-lock '~> 3.19'
-
 set :application, 'umasstransit.rodeo'
 set :repo_url, 'git@github.com:umts/umasstransit.rodeo.git'
 set :branch, 'main'
@@ -10,5 +7,7 @@ set :branch, 'main'
 set :deploy_to, '/srv/rodeo/'
 
 append :linked_files, 'config/database.yml', 'config/roadeo.yml'
+append :linked_dirs, 'log', 'tmp/pids'
 
-append :linked_dirs, 'log', 'tmp/pids', 'node_modules'
+set :bundle_version, 4
+set :passenger_restart_with_sudo, true


### PR DESCRIPTION
* Remove config lock
* NPM refuses to install into a sym-link anyways
* Bundler 4 deprecation warnings
* Some change I made to the server requires sudo to restart Passenger, now